### PR TITLE
Refactor: Move UI structure to HTML, JS for behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,77 @@
 </head>
 
 <body>
-    <div id="app"></div>
+    <div id="app">
+        <div class="controls" id="controlsContainer">
+            <!-- Tipo de Carta -->
+            <div>
+                <label for="tipoSelect">Tipo de carta:</label>
+                <select id="tipoSelect"></select>
+            </div>
+            <br>
+
+            <!-- Tema del marco -->
+            <div>
+                <label for="temaMarcoSelect">Tema del marco:</label>
+                <select id="temaMarcoSelect"></select>
+            </div>
+            <br>
+
+            <!-- Fondo -->
+            <div>
+                <label for="fondoSelect">Fondo:</label>
+                <select id="fondoSelect"></select>
+            </div>
+            <br>
+
+            <!-- Icono Tipo & Clan -->
+            <div>
+                <label for="iconoTipoSelect">Icono Tipo:</label>
+                <select id="iconoTipoSelect"></select>
+                <label for="clanSelect" style="margin-left: 10px;">Clan:</label>
+                <select id="clanSelect"></select>
+            </div>
+            <br>
+
+            <!-- Nombre -->
+            <div>
+                <input type="text" id="nombreInput" placeholder="Nombre" style="width: calc(50% - 5px); margin-right: 5px;">
+            <!-- Descripción -->
+                <textarea id="descInput" placeholder="Descripción" style="width: calc(50% - 5px);"></textarea>
+            </div>
+            <br>
+
+            <!-- File Input -->
+            <div>
+                <input type="file" id="fileInput" accept="image/*">
+            </div>
+            <br>
+
+            <!-- Image Position Sliders -->
+            <div class="slider-container">
+                <div>
+                    <label for="sliderX">Posición horizontal:</label>
+                    <input type="range" id="sliderX" min="-2000" max="2000" value="0" class="position-slider">
+                    <span id="sliderXValue" class="slider-value">0</span>
+                </div>
+                <div>
+                    <label for="sliderY">Posición vertical:</label>
+                    <input type="range" id="sliderY" min="-2000" max="2000" value="0" class="position-slider">
+                    <span id="sliderYValue" class="slider-value">0</span>
+                </div>
+            </div>
+            <br>
+
+            <!-- Export Button -->
+            <div>
+                <button id="exportBtn">Exportar como PNG</button>
+            </div>
+        </div>
+
+        <div id="canvas" class="canvas">
+            <div id="card" class="carta"></div>
+        </div>
+    </div>
 
     <script src="lib/html2canvas.min.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,3 @@
-import { exportCard } from "./export.js";
-import { createUI } from "./ui.js";
+import { initializeUI } from "./ui.js";
 
-createUI({ exportCard });
+initializeUI();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,128 +1,7 @@
 import { exportCard } from "./export.js";
 import { cargarClanes, cargarRecursos } from "./dataLoader.js";
 
-// Helper functions
-function createLabeledSelect(labelText, optionsArray, onChangeCallback) {
-  const label = document.createElement("label");
-  label.textContent = labelText;
-
-  const select = document.createElement("select");
-  optionsArray.forEach((option) => {
-    const opt = document.createElement("option");
-    if (typeof option === "string") {
-      opt.value = option;
-      opt.textContent = option;
-    } else {
-      opt.value = option.value;
-      opt.textContent = option.name;
-    }
-    select.appendChild(opt);
-  });
-
-  if (onChangeCallback) {
-    select.addEventListener("change", onChangeCallback);
-  }
-
-  // Returning the select element directly, label is handled by text node or specific label element.
-  // The original code often had text nodes like "Tipo de carta:" directly appended.
-  // For more complex cases, a container div might be better, but this aligns with current structure.
-  // Let's refine this: the prompt asked for label and select.
-  // The original code uses text nodes for labels. We'll create a proper label element.
-  const container = document.createElement('div');
-  // container.appendChild(label); // The original code appends text nodes, then the select.
-                                // We will return select and the caller can decide how to add the label.
-                                // Let's return an object with label and select for flexibility.
-  // No, the prompt says: "Appends the label and select to a container div or directly returns them"
-  // "Returns the created elements (e.g., the container div or the select element itself if the label is handled separately)."
-  // The original code structure is `controles.append(document.createTextNode("Label text:"), selectElement)`.
-  // So, it's better to return just the select element and let the caller handle the label.
-  // Or, create the label and return both, and the caller can append them.
-  // Let's stick to returning the select element and let createUI handle the label text node for now to minimize changes to createUI's append structure.
-  // Upon review, the prompt is clearer: "Creates a `<label>`, a `<select>` element... Appends the label and select to a container `div`... Returns the created elements (e.g., the container div)"
-  // So, a container div with label and select is appropriate.
-  
-  const controlContainer = document.createElement("div");
-  controlContainer.appendChild(label);
-  controlContainer.appendChild(select);
-  // To maintain similar spacing as original (which used <br>), we might add a br here or handle it in createUI
-  return { element: controlContainer, selectElement: select };
-}
-
-function createTextInput(placeholder, onInputCallback) {
-  const input = document.createElement("input");
-  input.type = "text";
-  input.placeholder = placeholder;
-  if (onInputCallback) {
-    input.addEventListener("input", onInputCallback);
-  }
-  return input;
-}
-
-function createTextArea(placeholder, onInputCallback) {
-  const textarea = document.createElement("textarea");
-  textarea.placeholder = placeholder;
-  if (onInputCallback) {
-    textarea.addEventListener("input", onInputCallback);
-  }
-  return textarea;
-}
-
-function createFileInput(accept, onChangeCallback) {
-  const input = document.createElement("input");
-  input.type = "file";
-  input.accept = accept;
-  if (onChangeCallback) {
-    input.addEventListener("change", onChangeCallback);
-  }
-  return input;
-}
-
-function createImagePositionSliders(min, max, initialValue, onInputXCallback, onInputYCallback) {
-  const container = document.createElement("div");
-  container.className = "slider-container";
-
-  // Slider X
-  const labelX = document.createElement("label");
-  labelX.textContent = "Posición horizontal:";
-  const sliderX = document.createElement("input");
-  sliderX.type = "range";
-  sliderX.min = min;
-  sliderX.max = max;
-  sliderX.value = initialValue;
-  sliderX.className = "position-slider";
-  const valueX = document.createElement("span");
-  valueX.className = "slider-value";
-  valueX.textContent = initialValue;
-
-  sliderX.addEventListener("input", (event) => {
-      if (onInputXCallback) onInputXCallback(event);
-      valueX.textContent = sliderX.value; // Update value display
-  });
-  
-
-  // Slider Y
-  const labelY = document.createElement("label");
-  labelY.textContent = "Posición vertical:";
-  const sliderY = document.createElement("input");
-  sliderY.type = "range";
-  sliderY.min = min;
-  sliderY.max = max;
-  sliderY.value = initialValue;
-  sliderY.className = "position-slider";
-  const valueY = document.createElement("span");
-  valueY.className = "slider-value";
-  valueY.textContent = initialValue;
-
-  sliderY.addEventListener("input", (event) => {
-      if (onInputYCallback) onInputYCallback(event);
-      valueY.textContent = sliderY.value; // Update value display
-  });
-  
-  container.append(labelX, sliderX, valueX, document.createElement("br"), labelY, sliderY, valueY);
-  // Return all relevant elements so they can be accessed if needed (e.g. for resetting values)
-  return { sliderContainer: container, sliderX, sliderY, sliderXValue: valueX, sliderYValue: valueY };
-}
-
+// createImageElement remains as it's used by card rendering functions
 function createImageElement(opciones, imageClassName, containerElement) {
   if (!opciones.imagen) {
     return null;
@@ -188,107 +67,105 @@ const opciones = {
   imagenAlto: 0, // Alto original de la imagen
 };
 
-export async function createUI() {
-  const app = document.getElementById("app");
-  const controles = document.createElement("div");
-  controles.className = "controls";
-
-  const card = document.createElement("div"); // Defined early as it's needed by listeners
-  card.id = "card";
-  card.className = "carta";
+export async function initializeUI() {
+  // Get references to static elements
+  const tipoSelect = document.getElementById('tipoSelect');
+  const temaMarcoSelect = document.getElementById('temaMarcoSelect');
+  const fondoSelect = document.getElementById('fondoSelect');
+  const iconoTipoSelect = document.getElementById('iconoTipoSelect');
+  const clanSelect = document.getElementById('clanSelect');
+  const nombreInput = document.getElementById('nombreInput');
+  const descInput = document.getElementById('descInput');
+  const fileInput = document.getElementById('fileInput');
+  const sliderX = document.getElementById('sliderX');
+  const sliderXValue = document.getElementById('sliderXValue');
+  const sliderY = document.getElementById('sliderY');
+  const sliderYValue = document.getElementById('sliderYValue');
+  const exportBtn = document.getElementById('exportBtn');
+  const card = document.getElementById('card');
 
   // Cargar recursos
   const recursos = await cargarRecursos();
   const clanes = await cargarClanes();
 
-  // Helper function for select callbacks
-  const createSelectCallback = (optionKey) => (event) => {
-    opciones[optionKey] = event.target.value;
-    renderCard(card);
-  };
-
+  // Populate Select Elements
   // Tipo de Carta
-  const tipoCartaControl = createLabeledSelect(
-    "Tipo de carta:",
-    ["Estándar", "Minimalista"],
-    createSelectCallback("tipo")
-  );
-  const tipoSelect = tipoCartaControl.selectElement; // Keep ref for direct access if needed later
+  ["Estándar", "Minimalista"].forEach(tipo => {
+    const opt = document.createElement("option");
+    opt.value = tipo;
+    opt.textContent = tipo;
+    tipoSelect.appendChild(opt);
+  });
 
   // Tema del marco
-  const temaMarcoControl = createLabeledSelect(
-    "Tema del marco:",
-    recursos.temasMarco,
-    createSelectCallback("tema")
-  );
-  const temaMarcoSelect = temaMarcoControl.selectElement;
+  recursos.temasMarco.forEach(tema => {
+    const opt = document.createElement("option");
+    opt.value = tema;
+    opt.textContent = tema;
+    temaMarcoSelect.appendChild(opt);
+  });
 
   // Fondo
-  const fondoControl = createLabeledSelect(
-    "Fondo:",
-    recursos.fondos, // Assuming this is an array of { value, name }
-    createSelectCallback("fondo")
-  );
-  const fondoSelect = fondoControl.selectElement;
+  recursos.fondos.forEach(({ value, name }) => {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = name;
+    fondoSelect.appendChild(opt);
+  });
 
   // Icono Tipo
-  const iconoTipoControl = createLabeledSelect(
-    "Icono Tipo:",
-    recursos.iconosTipo, // Assuming this is an array of { value, name }
-    createSelectCallback("iconoTipo")
-  );
-  const iconoTipoSelect = iconoTipoControl.selectElement;
+  recursos.iconosTipo.forEach(({ value, name }) => {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = name;
+    iconoTipoSelect.appendChild(opt);
+  });
 
   // Clan
-  const clanOptions = Object.entries(clanes).map(([nombre, ruta]) => ({ name: nombre, value: ruta }));
-  const clanControl = createLabeledSelect(
-    "Clan:",
-    clanOptions,
-    createSelectCallback("clan")
-  );
-  const clanSelect = clanControl.selectElement;
+  Object.entries(clanes).forEach(([nombre, ruta]) => {
+    const opt = document.createElement("option");
+    opt.value = ruta;
+    opt.textContent = nombre;
+    clanSelect.appendChild(opt);
+  });
 
-  // Nombre
-  const nombreInput = createTextInput("Nombre", (event) => {
-    opciones.nombre = event.target.value;
+  // Attach Event Listeners
+  tipoSelect.addEventListener("change", () => {
+    opciones.tipo = tipoSelect.value;
     renderCard(card);
   });
 
-  // Descripción
-  const descInput = createTextArea("Descripción", (event) => {
-    opciones.descripcion = event.target.value;
+  temaMarcoSelect.addEventListener("change", () => {
+    opciones.tema = temaMarcoSelect.value;
     renderCard(card);
   });
 
-  // Sliders for image position - must be defined before fileInput if fileInput resets them
-  const imageSliders = createImagePositionSliders(-2000, 2000, 0,
-    (event) => { // onInputXCallback
-      opciones.imagenPosX = parseInt(event.target.value);
-      const cardElement = document.getElementById('card');
-      if (cardElement) {
-        const imageElement = cardElement.querySelector('.imagen');
-        if (imageElement) {
-          imageElement.style.transform = `translate(${opciones.imagenPosX}px, ${opciones.imagenPosY}px)`;
-        }
-      }
-    },
-    (event) => { // onInputYCallback
-      opciones.imagenPosY = parseInt(event.target.value);
-      const cardElement = document.getElementById('card');
-      if (cardElement) {
-        const imageElement = cardElement.querySelector('.imagen');
-        if (imageElement) {
-          imageElement.style.transform = `translate(${opciones.imagenPosX}px, ${opciones.imagenPosY}px)`;
-        }
-      }
-    }
-  );
-  // Destructure for clarity if needed, or use imageSliders.sliderX, etc.
-  const { sliderContainer, sliderX, sliderY, sliderXValue, sliderYValue } = imageSliders;
+  fondoSelect.addEventListener("change", () => {
+    opciones.fondo = fondoSelect.value;
+    renderCard(card);
+  });
 
+  iconoTipoSelect.addEventListener("change", () => {
+    opciones.iconoTipo = iconoTipoSelect.value;
+    renderCard(card);
+  });
 
-  // File Input
-  const fileInput = createFileInput("image/*", (e) => {
+  clanSelect.addEventListener("change", () => {
+    opciones.clan = clanSelect.value;
+    renderCard(card);
+  });
+
+  nombreInput.addEventListener("input", () => {
+    opciones.nombre = nombreInput.value;
+    renderCard(card);
+  });
+
+  descInput.addEventListener("input", () => {
+    opciones.descripcion = descInput.value;
+    renderCard(card);
+  });
+
+  fileInput.addEventListener("change", (e) => {
     const file = e.target.files[0];
     if (!file) return;
     const reader = new FileReader();
@@ -300,11 +177,10 @@ export async function createUI() {
         opciones.imagenAlto = imgTemp.naturalHeight;
         opciones.imagenPosX = 0;
         opciones.imagenPosY = 0;
-        // Reset sliders to 0 when a new image is loaded
-        if (sliderX) sliderX.value = 0;
-        if (sliderY) sliderY.value = 0;
-        if (sliderXValue) sliderXValue.textContent = "0";
-        if (sliderYValue) sliderYValue.textContent = "0";
+        sliderX.value = 0;
+        sliderY.value = 0;
+        sliderXValue.textContent = "0";
+        sliderYValue.textContent = "0";
         renderCard(card);
       };
       imgTemp.src = ev.target.result;
@@ -312,33 +188,31 @@ export async function createUI() {
     reader.readAsDataURL(file);
   });
 
-  const exportBtn = document.createElement("button");
-  exportBtn.textContent = "Exportar como PNG";
+  sliderX.addEventListener("input", () => {
+    opciones.imagenPosX = parseInt(sliderX.value);
+    sliderXValue.textContent = sliderX.value;
+    const cardElement = document.getElementById('card'); // or use the 'card' variable directly
+    if (cardElement) {
+      const imageElement = cardElement.querySelector('.imagen');
+      if (imageElement) {
+        imageElement.style.transform = `translate(${opciones.imagenPosX}px, ${opciones.imagenPosY}px)`;
+      }
+    }
+  });
+
+  sliderY.addEventListener("input", () => {
+    opciones.imagenPosY = parseInt(sliderY.value);
+    sliderYValue.textContent = sliderY.value;
+    const cardElement = document.getElementById('card'); // or use the 'card' variable directly
+    if (cardElement) {
+      const imageElement = cardElement.querySelector('.imagen');
+      if (imageElement) {
+        imageElement.style.transform = `translate(${opciones.imagenPosX}px, ${opciones.imagenPosY}px)`;
+      }
+    }
+  });
+
   exportBtn.onclick = exportCard;
-
-  controles.append(
-    tipoCartaControl.element,
-    temaMarcoControl.element,
-    fondoControl.element,
-    iconoTipoControl.element,
-    clanControl.element,
-    nombreInput,
-    descInput,
-    document.createElement("br"), // Maintain some separation if needed
-    fileInput,
-    document.createElement("br"), // Maintain some separation
-    sliderContainer, // This is the container div from createImagePositionSliders
-    document.createElement("br"),
-    exportBtn
-  );
-
-  const canvas = document.createElement("div");
-  canvas.id = "canvas";
-  canvas.className = "canvas";
-
-  // Card element was created earlier
-  canvas.appendChild(card);
-  app.append(controles, canvas);
 
   // Initial render
   renderCard(card);


### PR DESCRIPTION
I've restructured the application to define the UI layout and elements directly in index.html. The JavaScript in js/ui.js has been refactored to manage these static HTML elements rather than creating them dynamically.

Key changes:
- index.html: Now contains the full HTML structure for all UI controls (selects, inputs, sliders, buttons) and the card display area. Elements are given appropriate IDs.
- js/ui.js:
    - I renamed createUI to initializeUI.
    - I removed dynamic DOM element creation for UI controls.
    - I removed helper functions for building UI elements.
    - initializeUI now uses document.getElementById() to get references to static elements.
    - Select elements are populated with options dynamically using loaded data.
    - Event listeners are attached to the static elements, with core behavior logic preserved.
- js/main.js: I updated this to call initializeUI() and removed a now unused import.

This architectural change aims to simplify UI management, make CSS styling more straightforward by having a static HTML structure, and align with common web development patterns.