### PR TITLE
Add remote image URL support

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
             </div>
             <br>
 
+            <!-- URL Input -->
+            <div>
+                <input type="text" id="urlInput" placeholder="URL de la imagen">
+            </div>
+            <br>
+
             <!-- Image Position Sliders -->
             <div class="slider-container">
                 <div>

--- a/js/cardRenderer.js
+++ b/js/cardRenderer.js
@@ -17,10 +17,16 @@ function createImageElement(opciones, imageClassName, containerElement) {
 
   const imagen = document.createElement("img");
   imagen.className = `imagen ${imageClassName || ""}`.trim();
+  if (!opciones.imagen.startsWith('data:')) {
+    imagen.crossOrigin = 'anonymous';
+  }
   imagen.src = opciones.imagen;
   imagen.style.transform = `translate(${opciones.imagenPosX}px, ${opciones.imagenPosY}px)`;
 
   const imgTemp = new Image();
+  if (!opciones.imagen.startsWith('data:')) {
+    imgTemp.crossOrigin = 'anonymous';
+  }
   imgTemp.src = opciones.imagen;
 
   imgTemp.onload = function () {

--- a/js/export.js
+++ b/js/export.js
@@ -1,6 +1,6 @@
 export function exportCard() {
   const canvas = document.getElementById("canvas");
-  html2canvas(canvas).then((canvas) => {
+  html2canvas(canvas, { useCORS: true }).then((canvas) => {
     const link = document.createElement("a");
     link.download = "carta.png";
     link.href = canvas.toDataURL();

--- a/js/ui.js
+++ b/js/ui.js
@@ -27,6 +27,7 @@ export async function initializeUI() {
   const nombreInput = document.getElementById('nombreInput');
   const descInput = document.getElementById('descInput');
   const fileInput = document.getElementById('fileInput');
+  const urlInput = document.getElementById('urlInput');
   const sliderX = document.getElementById('sliderX');
   const sliderXValue = document.getElementById('sliderXValue');
   const sliderY = document.getElementById('sliderY');
@@ -135,7 +136,30 @@ export async function initializeUI() {
       };
       imgTemp.src = ev.target.result;
     };
-    reader.readAsDataURL(file);
+  reader.readAsDataURL(file);
+  });
+
+  urlInput.addEventListener("change", () => {
+    const url = urlInput.value.trim();
+    if (!url) return;
+    const imgTemp = new Image();
+    imgTemp.crossOrigin = "anonymous";
+    imgTemp.onload = function() {
+      opciones.imagen = url;
+      opciones.imagenAncho = imgTemp.naturalWidth;
+      opciones.imagenAlto = imgTemp.naturalHeight;
+      opciones.imagenPosX = 0;
+      opciones.imagenPosY = 0;
+      sliderX.value = 0;
+      sliderY.value = 0;
+      sliderXValue.textContent = "0";
+      sliderYValue.textContent = "0";
+      renderCard(card);
+    };
+    imgTemp.onerror = function() {
+      console.error("Error loading image from URL:", url);
+    };
+    imgTemp.src = url;
   });
 
   sliderX.addEventListener("input", () => {


### PR DESCRIPTION
## Summary
- allow users to specify a remote image URL
- add CORS handling on image elements
- enable CORS for html2canvas export

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc42cd04832b830a97d58c8195aa